### PR TITLE
Odstranjena odvečna vrstica

### DIFF
--- a/binder/start
+++ b/binder/start
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 export BOTTLE_PORT=8080
 export BOTTLE_RELOADER=1


### PR DESCRIPTION
Da se bo aplikacija na Binderju sploh zagnala, bo potrebno odstraniti odvečno vrstico v skripti `start`, kar lahko storite tako, da sprejmete tale pull request. Seveda poskrbite tudi za spremembe iz #1, da bodo povezave in obrazci v aplikaciji delovali.